### PR TITLE
Fix compatibly with PDN v4.2.16

### DIFF
--- a/StyleTransfer/StyleTransferEffect/Plugin/StyleTransferEffect.cs
+++ b/StyleTransfer/StyleTransferEffect/Plugin/StyleTransferEffect.cs
@@ -248,7 +248,7 @@ namespace PaintDotNet.Effects.ML.StyleTransfer.Plugin
                 if (tileSize > 0)
                 {
                     var tileFormat = StringResources.Get("TileInfoFormat");
-                    var renderer = new TiledRenderer(SrcArgs.ISurface, DstArgs.ISurface, tileSize, MARGIN);
+                    var renderer = new TiledRenderer(SrcArgs.Surface, DstArgs.Surface, tileSize, MARGIN);
                     renderer.Update += UpdateTiled;
                     renderer.Process(graph);
 
@@ -264,7 +264,7 @@ namespace PaintDotNet.Effects.ML.StyleTransfer.Plugin
                     graph.Update += UpdateGraph;
                     var result = graph.Run();
                     graph.Update -= UpdateGraph;
-                    result.ToSurface(DstArgs.ISurface);
+                    result.ToSurface(DstArgs.Surface);
 
                     void UpdateGraph(object sender, EffectGraphEventArgs e)
                     {


### PR DESCRIPTION
The `ISurface` property became private in 4.2.16.  You can still use the `Surface` property though.